### PR TITLE
Maintenance task: do not change IPv4 ip_port_mappings

### DIFF
--- a/ovn_octavia_provider/maintenance.py
+++ b/ovn_octavia_provider/maintenance.py
@@ -160,12 +160,13 @@ class DBInconsistenciesPeriodics(object):
                     break
                 port_uuid, src_ip = v.split(':', 1)
                 mappings[f'[{k}]'] = f'{port_uuid}:[{src_ip}]'
-            self.ovn_nbdb_api.db_clear('Load_Balancer', lb.uuid,
-                                       'ip_port_mappings').execute(
-                check_error=True)
-            self.ovn_nbdb_api.db_set('Load_Balancer', lb.uuid,
-                                     ('ip_port_mappings', mappings)).execute(
-                check_error=True)
+            if mappings:
+                self.ovn_nbdb_api.db_clear(
+                    'Load_Balancer', lb.uuid, 'ip_port_mappings'
+                ).execute(check_error=True)
+                self.ovn_nbdb_api.db_set(
+                    'Load_Balancer', lb.uuid, ('ip_port_mappings', mappings)
+                ).execute(check_error=True)
 
         LOG.debug('Maintenance task: no more ip_port_mappings to format, '
                   'stopping the periodic task.')

--- a/ovn_octavia_provider/tests/unit/test_maintenance.py
+++ b/ovn_octavia_provider/tests/unit/test_maintenance.py
@@ -187,11 +187,7 @@ class TestDBInconsistenciesPeriodics(ovn_base.TestOvnOctaviaBase):
             '[fda2:918e:5869:0:f816:3eff:fe64:adf8]':
                 'f2b97caf-da62-4db9-91da-bc11f2ac3935:'
                 '[fda2:918e:5869:0:f816:3eff:fe81:61d0]'}
-        expected_call_db_clear = [
-            mock.call('Load_Balancer', 'foo1', 'ip_port_mappings')]
-        self.maint.ovn_nbdb_api.db_clear.assert_has_calls(
-            expected_call_db_clear)
-        expected_call_db_set = [
-            mock.call('Load_Balancer', 'foo1', ('ip_port_mappings', mapping1))]
-        self.maint.ovn_nbdb_api.db_set.assert_has_calls(
-            expected_call_db_set)
+        self.maint.ovn_nbdb_api.db_clear.assert_called_once_with(
+            'Load_Balancer', 'foo1', 'ip_port_mappings')
+        self.maint.ovn_nbdb_api.db_set.assert_called_once_with(
+            'Load_Balancer', 'foo1', ('ip_port_mappings', mapping1))

--- a/releasenotes/notes/maintenance-task-bugfix-2072754-cc20f614de657747.yaml
+++ b/releasenotes/notes/maintenance-task-bugfix-2072754-cc20f614de657747.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    [`bug 2072754 <https://bugs.launchpad.net/neutron/+bug/2072754>`_]
+    Fixed maintenance task that was breaking IPv4 load balancers with health
+    monitors.


### PR DESCRIPTION
IPv4 port mappings would get cleared by format_ip_port_mappings_ipv6(), breaking load balancers with health monitors.

Change-Id: Ia29fd3c533b40f6eb13278a163ebb95465d77a99 Closes-Bug: #2072754
Co-Authored-By: Pierre Riteau <pierre@stackhpc.com>
(cherry picked from commit 683e644b86b8425699733deb8ab6fe4e4dd352bf)