### PR TITLE
Respect passed arguments for Neutron client connection

### DIFF
--- a/ovn_octavia_provider/common/clients.py
+++ b/ovn_octavia_provider/common/clients.py
@@ -118,11 +118,19 @@ class NeutronAuth(metaclass=Singleton):
         try:
             ksession = KeystoneSession('neutron')
 
-            kwargs = {}
+            kwargs = {'region_name': CONF.neutron.region_name}
+            try:
+                interface = CONF.neutron.valid_interfaces[0]
+            except (TypeError, LookupError):
+                interface = CONF.neutron.valid_interfaces
+            if interface:
+                kwargs['interface'] = interface
             if CONF.neutron.endpoint_override:
                 kwargs['network_endpoint_override'] = (
                     CONF.neutron.endpoint_override)
-
+                if CONF.neutron.endpoint_override.startswith("https"):
+                    kwargs['insecure'] = CONF.neutron.insecure
+                    kwargs['cacert'] = CONF.neutron.cafile
             self.network_proxy = openstack.connection.Connection(
                 session=ksession.session, **kwargs).network
         except Exception:

--- a/ovn_octavia_provider/tests/unit/common/test_clients.py
+++ b/ovn_octavia_provider/tests/unit/common/test_clients.py
@@ -98,6 +98,8 @@ class TestNeutronAuth(base.BaseTestCase):
     def setUp(self):
         super().setUp()
         config.register_opts()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.conf.config(group='neutron', region_name='RegionOne')
         self.mock_client = mock.patch(
             'openstack.connection.Connection').start()
         clients.Singleton._instances = {}
@@ -106,7 +108,7 @@ class TestNeutronAuth(base.BaseTestCase):
     def test_init(self, mock_ks):
         clients.NeutronAuth()
         self.mock_client.assert_called_once_with(
-            session=mock_ks().session)
+            session=mock_ks().session, region_name='RegionOne')
 
     def test_singleton(self):
         c1 = clients.NeutronAuth()

--- a/releasenotes/notes/add-neutron-client-interface-info-6a018cad49b5d240.yaml
+++ b/releasenotes/notes/add-neutron-client-interface-info-6a018cad49b5d240.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed wrong endpoint information in Neutron client configuration.


### PR DESCRIPTION
At the moment quite vital arguments, as region_name, valid_interfaces are ignored by the plugin which results in inconsistent behaviour with Octavia itself, when trying to interact with Neutron. For instance, while Octavia connects to the Neutron through internal endpoint, the plugin still tries to reach through public one ignoring options defined in [service_auth] and [neutron] sections.

This patch is basically a copy-paste from Octavia client fix [1]

[1] https://review.opendev.org/c/openstack/octavia/+/905794
Related-Bug: #2049551

Change-Id: I3a98825e40143dfa9017ca512a27197c48c31ee9