### PR TITLE
Respect passed arguments for Neutron client connection 

### DIFF
--- a/ovn_octavia_provider/common/clients.py
+++ b/ovn_octavia_provider/common/clients.py
@@ -118,11 +118,19 @@ class NeutronAuth(metaclass=Singleton):
         try:
             ksession = KeystoneSession('neutron')
 
-            kwargs = {}
+            kwargs = {'region_name': CONF.neutron.region_name}
+            try:
+                interface = CONF.neutron.valid_interfaces[0]
+            except (TypeError, LookupError):
+                interface = CONF.neutron.valid_interfaces
+            if interface:
+                kwargs['interface'] = interface
             if CONF.neutron.endpoint_override:
                 kwargs['network_endpoint_override'] = (
                     CONF.neutron.endpoint_override)
-
+                if CONF.neutron.endpoint_override.startswith("https"):
+                    kwargs['insecure'] = CONF.neutron.insecure
+                    kwargs['cacert'] = CONF.neutron.cafile
             self.network_proxy = openstack.connection.Connection(
                 session=ksession.session, **kwargs).network
         except Exception:

--- a/ovn_octavia_provider/tests/unit/common/test_clients.py
+++ b/ovn_octavia_provider/tests/unit/common/test_clients.py
@@ -99,6 +99,9 @@ class TestNeutronAuth(base.BaseTestCase):
     def setUp(self):
         super().setUp()
         config.register_opts()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.conf.config(group='neutron', region_name='RegionOne',
+                         valid_interfaces='internal')
         self.mock_client = mock.patch(
             'openstack.connection.Connection').start()
         clients.Singleton._instances = {}
@@ -107,7 +110,8 @@ class TestNeutronAuth(base.BaseTestCase):
     def test_init(self, mock_ks):
         clients.NeutronAuth()
         self.mock_client.assert_called_once_with(
-            session=mock_ks().session)
+            session=mock_ks().session, interface='internal',
+            region_name='RegionOne')
 
     def test_singleton(self):
         c1 = clients.NeutronAuth()
@@ -133,7 +137,8 @@ class TestNeutronAuth(base.BaseTestCase):
     def test_get_client(self, mock_ks):
         clients.get_neutron_client()
         self.mock_client.assert_called_once_with(
-            session=mock_ks().session)
+            session=mock_ks().session, interface='internal',
+            region_name='RegionOne')
 
     @mock.patch.object(clients, 'NeutronAuth', side_effect=[RuntimeError])
     def test_get_client_error(self, mock_ks):

--- a/releasenotes/notes/add-neutron-client-interface-info-6a018cad49b5d240.yaml
+++ b/releasenotes/notes/add-neutron-client-interface-info-6a018cad49b5d240.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    [`bug 2110488 <https://bugs.launchpad.net/neutron/+bug/2110488>`_]
+    Fixed wrong endpoint information in Neutron client configuration.


### PR DESCRIPTION
At the moment quite vital arguments, such as region_name and valid_interfaces, are ignored by the plugin, which results in inconsistent behaviour with Octavia when trying to interact with Neutron.

For instance, while Octavia connects to Neutron through the internal endpoint, the plugin still tries to reach it through the public one, ignoring options defined in [service_auth] and [neutron] sections.

This patch is basically a copy-paste from Octavia [1].

[1] https://review.opendev.org/c/openstack/octavia/+/905794

Related-Bug: #2049551

Change-Id: I3a98825e40143dfa9017ca512a27197c48c31ee9 (cherry picked from commit 42181497a18c2c92a5e77bff6317a7cbb329537e)